### PR TITLE
Coddle newly spawned players

### DIFF
--- a/lua/cfc_random_spawn/module/sv_player_spawning.lua
+++ b/lua/cfc_random_spawn/module/sv_player_spawning.lua
@@ -239,7 +239,7 @@ local function getMostEnclosedSpawn( spawns )
     local spawnsWithCounts = {}
     for _, spawn in ipairs( freeSpawns ) do
         local entsThatPlyWillLoad = ents.FindInPVS( spawn.spawnPos )
-        spawnsWithCounts[ #entsThatPlyWillLoad ] = spawn
+        spawnsWithCounts[#entsThatPlyWillLoad] = spawn
 
         if #entsThatPlyWillLoad < 250 then break end -- this one is fine, just break here.
     end

--- a/lua/cfc_random_spawn/module/sv_player_spawning.lua
+++ b/lua/cfc_random_spawn/module/sv_player_spawning.lua
@@ -199,9 +199,9 @@ local function findFreeSpawnPoint( spawns, plys )
 end
 
 -- for below func
-local roofUpOffset = Vector( 0, 0, 2000 )
+local roofUpOffset = Vector( 0, 0, 500 )
 
--- find generally indoor spawns
+-- find spawns that are roofed
 local function getRoofedSpawns( spawns )
     local spawnsUnderARoof = {}
     local roofTrace = {

--- a/lua/cfc_random_spawn/module/sv_player_spawning.lua
+++ b/lua/cfc_random_spawn/module/sv_player_spawning.lua
@@ -13,10 +13,10 @@ local CLOSENESS_LIMIT = CFCRandomSpawn.Config.CLOSENESS_LIMIT ^ 2
 local CENTER_UPDATE_INTERVAL = customSpawnConfigForMap.centerUpdateInterval or CFCRandomSpawn.Config.CENTER_UPDATE_INTERVAL
 local IGNORE_BUILDERS = CFCRandomSpawn.Config.IGNORE_BUILDERS
 
-local DYNAMIC_CENTER_MINSIZE = 1750 -- getDynamicPvpCenter starts at this radius
-local DYNAMIC_CENTER_MAXSIZE = 3750 -- no bigger than this radius
+local DYNAMIC_CENTER_MINSIZE = 2000 -- getDynamicPvpCenter starts at this radius
+local DYNAMIC_CENTER_MAXSIZE = 4000 -- no bigger than this radius
 local DYNAMIC_CENTER_MINSPAWNS = 10 -- getDynamicPvpCenter needs at least this many spawns inside the radius
-local DYNAMIC_CENTER_MAXSPAWNS = 30 -- max possible spawns
+local DYNAMIC_CENTER_MAXSPAWNS = 35 -- max possible spawns
 local DYNAMIC_CENTER_SPAWNCOUNTMATCHPVPERS = true -- pvp center gets bigger when more people are pvping
 local DYNAMIC_CENTER_IMPERFECT = true -- throw a bit of randomness in, makes pvp less stiff.
 

--- a/lua/cfc_random_spawn/module/sv_player_spawning.lua
+++ b/lua/cfc_random_spawn/module/sv_player_spawning.lua
@@ -62,6 +62,7 @@ function CFCRandomSpawn.refreshMapInfo()
     CENTER_UPDATE_INTERVAL = customSpawnConfigForMap.centerUpdateInterval or CFCRandomSpawn.Config.CENTER_UPDATE_INTERVAL
     IGNORE_BUILDERS = CFCRandomSpawn.Config.IGNORE_BUILDERS
 
+    -- purge this since it could now be outdated
     CFCRandomSpawn.spawnsUnderARoof = nil
 
     loadPvpCenters()
@@ -394,6 +395,8 @@ function CFCRandomSpawn.getMostEnclosedSpawnPos()
         CFCRandomSpawn.spawnsUnderARoof = getEnclosedSpawns( customSpawnsForMap )
     end
 
+    -- use spawns under a roof if we can, because this function is pretty expensive, 
+    -- finds all entities in every spawnpoint's PVS, we want to run it on as few spawns as possible.
     local mostEnclosedSpawn = getMostEnclosedSpawn( CFCRandomSpawn.spawnsUnderARoof )
     return mostEnclosedSpawn.spawnPos, mostEnclosedSpawn.spawnAngle
 end

--- a/lua/cfc_random_spawn/module/sv_player_spawning.lua
+++ b/lua/cfc_random_spawn/module/sv_player_spawning.lua
@@ -20,7 +20,7 @@ local DYNAMIC_CENTER_MAXSPAWNS = 30 -- max possible spawns
 local DYNAMIC_CENTER_SPAWNCOUNTMATCHPVPERS = true -- pvp center gets bigger when more people are pvping
 local DYNAMIC_CENTER_IMPERFECT = true -- throw a bit of randomness in, makes pvp less stiff.
 
-local PlayersWhoHaveSpawned = {}
+local playersWhoHaveSpawned = {}
 
 local function defaultPvpCenter()
     return pvpCenters[1]
@@ -404,8 +404,8 @@ function CFCRandomSpawn.handlePlayerSpawn( ply )
     if IsValid( ply.LinkedSpawnPoint ) then return end
 
     timer.Simple( 0, function()
-        local needsACarefulFirstSpawn = not PlayersWhoHaveSpawned[ply] and #player.GetAll() > 20
-        PlayersWhoHaveSpawned[ply] = true
+        local needsACarefulFirstSpawn = not playersWhoHaveSpawned[ply] and #player.GetAll() > 20
+        playersWhoHaveSpawned[ply] = true
 
         local optimalSpawnPosition, optimalSpawnAngles = nil, nil
         if needsACarefulFirstSpawn then -- need a careful spawn, player might crash out if we just put them anywhere

--- a/lua/cfc_random_spawn/sv_config.lua
+++ b/lua/cfc_random_spawn/sv_config.lua
@@ -1,5 +1,5 @@
 CFCRandomSpawn.Config.DEFAULT_CENTER_CUTOFF = 3000 -- Default cutoff range from the most popular pvp center, where players further away from this will be ignored. The system tries to place you closest to everyone else.
-CFCRandomSpawn.Config.CLOSENESS_LIMIT = 100 -- Will not choose spawnpoints that are within this many units of a valid player (i.e. a living pvper).
+CFCRandomSpawn.Config.CLOSENESS_LIMIT = 400 -- Will not choose spawnpoints that are within this many units of a valid player (i.e. a living pvper).
 CFCRandomSpawn.Config.SELECTION_SIZE = 16 -- Max number of 'ideal' spawnpoints to select from randomly.
 CFCRandomSpawn.Config.CENTER_UPDATE_INTERVAL = 120 -- The gap (in seconds) between each center popularity update. If set to 0, will update on every respawn.
 CFCRandomSpawn.Config.IGNORE_BUILDERS = true -- Should 'center popularity' and player position average not care about builders? Requires a PvP addon which uses a function of the form PLAYER:IsInPvp()


### PR DESCRIPTION
Dynamically put newly spawned players in the least resource intensive spawnpoints. Should stop some spawn-in crashing on maps like mobenix.