### PR TITLE
Tweaks

### DIFF
--- a/lua/cfc_random_spawn/module/sv_player_spawning.lua
+++ b/lua/cfc_random_spawn/module/sv_player_spawning.lua
@@ -209,9 +209,11 @@ end
 local function getPlyAvg( plys, centerPos )
     if not plys or not plys[1] then return centerPos or Vector() end
 
-    local avgSum = Vector()
+    local avgSum = plys[1]:GetPos()
+    if #plys == 1 then return avgSum end
 
-    for _, ply in ipairs( plys ) do
+    for i, ply in ipairs( plys ) do
+        if i == 1 then continue end -- already added their position
         avgSum = avgSum + ply:GetPos()
     end
 

--- a/lua/cfc_random_spawn/module/sv_player_spawning.lua
+++ b/lua/cfc_random_spawn/module/sv_player_spawning.lua
@@ -109,6 +109,7 @@ end )
 
 hook.Add( "PlayerDeath", "cfc_randomspawn_trackrecentcombatants", function( died, _inflictor, attacker )
     countAsCombatting( died )
+    if not attacker:IsPlayer() then return end
     countAsCombatting( attacker )
 end )
 

--- a/lua/cfc_random_spawn/module/sv_player_spawning.lua
+++ b/lua/cfc_random_spawn/module/sv_player_spawning.lua
@@ -13,7 +13,7 @@ local CLOSENESS_LIMIT = CFCRandomSpawn.Config.CLOSENESS_LIMIT ^ 2
 local CENTER_UPDATE_INTERVAL = customSpawnConfigForMap.centerUpdateInterval or CFCRandomSpawn.Config.CENTER_UPDATE_INTERVAL
 local IGNORE_BUILDERS = CFCRandomSpawn.Config.IGNORE_BUILDERS
 
-local ACTIVE_PLAYER_TIMEOUT = 120 -- players who haven't died/killed anyone in this many seconds aren't 'pvping' and shouldn't influence the pvp center, etc
+local ACTIVE_PLAYER_TIMEOUT = 120 -- players who haven't died/killed anyone in this many seconds aren't 'pvping' and won't influence the pvp center, etc
 
 local DYNAMIC_CENTER_MINSIZE = 2000 -- getDynamicPvpCenter starts at this radius
 local DYNAMIC_CENTER_MAXSIZE = 4000 -- no bigger than this radius
@@ -212,8 +212,8 @@ local function getPlyAvg( plys, centerPos )
     local avgSum = plys[1]:GetPos()
     if #plys == 1 then return avgSum end
 
-    for i, ply in ipairs( plys ) do
-        if i == 1 then continue end -- already added their position
+    for i = 2, #plys do
+        local ply = plys[i]
         avgSum = avgSum + ply:GetPos()
     end
 


### PR DESCRIPTION
Add simple little "recentCombatants" system
Makes the pvp center calculations ignore pvpers that aren't getting kills, etc
Was just noticing that centers weren't following pvp, this should help with that

And made some small changes that stops the code from dragging pvp centers towards vec0